### PR TITLE
Move the Dockerfile for the downstream trigger from the vic repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,15 @@
 
 SHELL = /bin/bash
 
-.PHONY: all check shellcheck
+.PHONY: all check shellcheck dockerfile_lint
 .DEFAULT_GOAL := all
 
 all: check
-check: shellcheck
+check: shellcheck dockerfile_lint
 
 shellcheck:
 	@shellcheck **/*.sh
+
+dockerfile_lint:
+	@docker run -it --rm --privileged -v $(PWD):/root/ projectatomic/dockerfile-lint dockerfile_lint -p -f images/*/Dockerfile
 

--- a/images/downstream/Dockerfile
+++ b/images/downstream/Dockerfile
@@ -1,12 +1,16 @@
 # Building:
-# docker build --no-cache -t vic-downstream .
-# docker tag vic-downstream gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
+# docker build --no-cache -t vic-downstream-trigger .
+# docker tag vic-downstream-trigger gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
-# docker tag vic-downstream wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
+# docker tag vic-downstream-trigger wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
 # docker login wdc-harbor-ci.eng.vmware.com/default-project
 # docker push wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
 FROM vmware/photon:2.0
+
+LABEL name="vic-downstream-trigger"
+# The version should be increased each time the file is changed
+LABEL version="1.4"
 
 RUN set -eux; \
      tdnf distro-sync --refresh -y; \

--- a/images/downstream/Dockerfile
+++ b/images/downstream/Dockerfile
@@ -1,0 +1,26 @@
+# Building:
+# docker build --no-cache -t vic-downstream .
+# docker tag vic-downstream gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
+# gcloud auth login
+# gcloud docker -- push gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
+# docker tag vic-downstream wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
+# docker login wdc-harbor-ci.eng.vmware.com/default-project
+# docker push wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
+FROM vmware/photon:2.0
+
+RUN set -eux; \
+     tdnf distro-sync --refresh -y; \
+     tdnf install gzip -y; \
+     tdnf install tar -y; \
+     tdnf info installed; \
+     tdnf clean all
+
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_amd64.tar.gz | tar zx && \
+    install drone /usr/bin
+
+RUN echo '#!/bin/bash' >> /usr/bin/trigger
+RUN echo 'num=$(drone build ls --format "{{.Number}} {{.Status}}" --event push --branch "$DOWNSTREAM_BRANCH" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
+RUN echo 'for i in {1..5}; do drone build start "$DOWNSTREAM_REPO" $num && break || sleep 15; done' >> /usr/bin/trigger
+RUN chmod +x /usr/bin/trigger
+
+ENTRYPOINT ["trigger"]


### PR DESCRIPTION
## Move downstream trigger Dockerfile from vic repo

Move the Dockerfile for triggering downstream Drone jobs into this
repository. Update its documentation.

##  Add labels to the downstream Dockerfile

This metadata documents the name and version of the image.

##  Use linter for static analysis of Dockerfiles

To help identify common Dockerfile mistakes, run dockerfile_lint on
all Dockerfiles. This will help ensure a baseline level of quality
for all Dockerfiles in this repository.