### PR TITLE
Fix shell script linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL = /bin/bash
+SHELL = /bin/bash -O globstar
 
 .PHONY: all check shellcheck dockerfile_lint
 .DEFAULT_GOAL := all

--- a/jenkins/jobs/trigger/nightly_trigger.sh
+++ b/jenkins/jobs/trigger/nightly_trigger.sh
@@ -24,7 +24,7 @@ JENKINS_JOB=$4
 JENKINS_URL=https://vic-jenkins.eng.vmware.com/
 JENKINS_USER=svc.vicuser
 JENKINS_PASSWD=bx741zG2rMN7G9PuXCh
-SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Get the latest build filename
 if [ "${REPO_BRANCH}" == "master" ]; then
@@ -32,7 +32,7 @@ if [ "${REPO_BRANCH}" == "master" ]; then
 else
     GS_PATH="${ARTIFACT_BUCKET}/${REPO_BRANCH}/"
 fi
-FILE_NAME=$(gsutil ls -l gs://${GS_PATH}${BINARY_PREFIX}* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | xargs basename)
+FILE_NAME=$(gsutil ls -l "gs://${GS_PATH}${BINARY_PREFIX}*" | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | xargs basename)
 
 # strip prefix and suffix from archive filename
 BUILD_NUM=${FILE_NAME#${BINARY_PREFIX}}
@@ -42,7 +42,7 @@ echo "Trigger build ${BUILD_NUM}"
 
 # Run test on vsphere 6.0, 6.5, 6.7 alternatively
 DAY="$(date +'%u')"
-REM=$(( $DAY % 3 ))
+REM=$(( "$DAY" % 3 ))
 if [ ${REM} -eq 0 ]; then
     export VC_BUILD_ID="ob-8217866"
     export ESX_BUILD_ID="ob-8169922"
@@ -60,4 +60,4 @@ echo "VC build: ${VC_BUILD_ID}"
 echo "ESX build: ${ESX_BUILD_ID}"
 echo "vSPhere version: ${VSPHERE_VERSION}"
 
-python ${SCRIPT_DIR}/jenkins_job_trigger.py "${JENKINS_URL}" "${JENKINS_USER}" "${JENKINS_PASSWD}" "${VSPHERE_VERSION}" "${VC_BUILD_ID}" "${ESX_BUILD_ID}" "${BUILD_NUM}" "${JENKINS_JOB}"
+python "${SCRIPT_DIR}/jenkins_job_trigger.py" "${JENKINS_URL}" "${JENKINS_USER}" "${JENKINS_PASSWD}" "${VSPHERE_VERSION}" "${VC_BUILD_ID}" "${ESX_BUILD_ID}" "${BUILD_NUM}" "${JENKINS_JOB}"


### PR DESCRIPTION
## Fix linting issues in nightly trigger script

Address shellcheck warnings related to preventing word splitting,
preventing globbing and word splitting, and arithmetic variables.

## Ensure that shellcheck considers all shell scripts

Explicitly enable globstar as a shell option to ensure that recursive
wildcards, like the one used for shellcheck, work as expected.